### PR TITLE
Adding units tests for Lookup3Hash, MurmurHash, BloomCalculations and Varint

### DIFF
--- a/src/test/java/com/clearspring/analytics/hash/Lookup3HashTest.java
+++ b/src/test/java/com/clearspring/analytics/hash/Lookup3HashTest.java
@@ -1,0 +1,144 @@
+// Copyright (c) Diffblue Limited. All rights reserved. 
+// Licensed under the Apache 2.0 license.
+
+package com.clearspring.analytics.hash;
+
+import com.clearspring.analytics.hash.Lookup3Hash;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class Lookup3HashTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void lookup3Input0PositiveNegativeNegativeOutputNegative() {
+
+    // Arrange
+    final int[] k = {};
+    final int offset = 262_145;
+    final int length = -2_147_483_643;
+    final int initval = -485_474_051;
+
+    // Act
+    final int retval = Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Assert result
+    Assert.assertEquals(-1_044_512_768, retval);
+  }
+
+  @Test
+  public void lookup3Input1ZeroPositiveNegativeOutputArrayIndexOutOfBoundsException() {
+
+    // Arrange
+    final int[] k = {-419_772_902};
+    final int offset = 0;
+    final int length = 11;
+    final int initval = -1_553_263_165;
+
+    // Act
+    thrown.expect(ArrayIndexOutOfBoundsException.class);
+    Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void lookup3Input2PositivePositivePositiveOutputArrayIndexOutOfBoundsException() {
+
+    // Arrange
+    final int[] k = {240_498_410, 16_843_272};
+    final int offset = 536_870_911;
+    final int length = 1;
+    final int initval = 992_639_440;
+
+    // Act
+    thrown.expect(ArrayIndexOutOfBoundsException.class);
+    Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void lookup3Input2ZeroPositiveNegativeOutputArrayIndexOutOfBoundsException() {
+
+    // Arrange
+    final int[] k = {-419_772_902, 0};
+    final int offset = 0;
+    final int length = 11;
+    final int initval = -1_553_263_165;
+
+    // Act
+    thrown.expect(ArrayIndexOutOfBoundsException.class);
+    Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void lookup3InputNullNegativePositivePositiveOutputNullPointerException() {
+
+    // Arrange
+    final int[] k = null;
+    final int offset = -2_147_483_647;
+    final int length = 6;
+    final int initval = 6208;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void lookup3InputNullPositivePositivePositiveOutputNullPointerException() {
+
+    // Arrange
+    final int[] k = null;
+    final int offset = 2_143_289_337;
+    final int length = 3;
+    final int initval = 551_731_363;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void lookup3InputNullPositivePositivePositiveOutputNullPointerException2() {
+
+    // Arrange
+    final int[] k = null;
+    final int offset = 2_143_289_337;
+    final int length = 2;
+    final int initval = 552_121_283;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    Lookup3Hash.lookup3(k, offset, length, initval);
+
+    // Method is not expected to return due to exception thrown
+  }
+  
+  @Test
+  public void lookup3ycsInput0NegativeNegativeNegativeOutputPositive() {
+
+    // Arrange
+    final int[] k = {};
+    final int offset = -2_147_483_647;
+    final int length = -1_610_612_735;
+    final int initval = -2_147_483_648;
+
+    // Act
+    final int retval = Lookup3Hash.lookup3ycs(k, offset, length, initval);
+
+    // Assert result
+    Assert.assertEquals(1_588_444_911, retval);
+  }
+}

--- a/src/test/java/com/clearspring/analytics/hash/MurmurHashTest.java
+++ b/src/test/java/com/clearspring/analytics/hash/MurmurHashTest.java
@@ -1,0 +1,281 @@
+// Copyright (c) Diffblue Limited. All rights reserved. 
+// Licensed under the Apache 2.0 license.
+
+package com.clearspring.analytics.hash;
+
+import com.clearspring.analytics.hash.MurmurHash;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class MurmurHashTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void hash64Input0NegativeOutputPositive() {
+
+    // Arrange
+    final byte[] data = {};
+    final int length = -1_825_536_057;
+
+    // Act
+    final long retval = MurmurHash.hash64(data, length);
+
+    // Assert result
+    Assert.assertEquals(532_139_613_051_938_052L, retval);
+  }
+
+  @Test
+  public void hash64Input0ZeroZeroOutputZero() {
+
+    // Arrange
+    final byte[] data = {};
+    final int length = 0;
+    final int seed = 0;
+
+    // Act
+    final long retval = MurmurHash.hash64(data, length, seed);
+
+    // Assert result
+    Assert.assertEquals(0L, retval);
+  }
+
+  @Test
+  public void hash64Input1PositivePositiveOutputPositive() {
+
+    // Arrange
+    final byte[] data = {(byte)0};
+    final int length = 1;
+    final int seed = 1_516_308_488;
+
+    // Act
+    final long retval = MurmurHash.hash64(data, length, seed);
+
+    // Assert result
+    Assert.assertEquals(8_112_217_426_270_966_022L, retval);
+  }
+
+  @Test
+  public void hash64InputNullPositiveNegativeOutputNullPointerException() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 41_595_974;
+    final int seed = -934_718_437;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hash64InputNullPositiveNegativeOutputNullPointerException2() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 7;
+    final int seed = -1_634_048_354;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hash64InputNullPositivePositiveOutputNullPointerException() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 2;
+    final int seed = 1_496_779_358;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hash64InputNullPositivePositiveOutputNullPointerException2() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 5;
+    final int seed = 625_996_457;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hash64InputNullPositivePositiveOutputNullPointerException3() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 6;
+    final int seed = 1_220_346_942;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hash64InputNullPositivePositiveOutputNullPointerException4() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 4;
+    final int seed = 2_129_536_234;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hash64InputNullPositivePositiveOutputNullPointerException5() {
+
+    // Arrange
+    final byte[] data = null;
+    final int length = 3;
+    final int seed = 769_686_320;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    MurmurHash.hash64(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hashInput0OutputNegative() {
+
+    // Arrange
+    final byte[] data = {};
+
+    // Act
+    final int retval = MurmurHash.hash(data);
+
+    // Assert result
+    Assert.assertEquals(-1_285_986_640, retval);
+  }
+
+  @Test
+  public void hashInput0PositivePositiveOutputArrayIndexOutOfBoundsException() {
+
+    // Arrange
+    final byte[] data = {};
+    final int length = 536_870_912;
+    final int seed = 536_870_912;
+
+    // Act
+    thrown.expect(ArrayIndexOutOfBoundsException.class);
+    MurmurHash.hash(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+
+  @Test
+  public void hashInput0ZeroOutputZero() {
+
+    // Arrange
+    final byte[] data = {};
+    final int seed = 0;
+
+    // Act
+    final int retval = MurmurHash.hash(data, seed);
+
+    // Assert result
+    Assert.assertEquals(0, retval);
+  }
+
+  @Test
+  public void hashInput0ZeroZeroOutputZero() {
+
+    // Arrange
+    final byte[] data = {};
+    final int length = 0;
+    final int seed = 0;
+
+    // Act
+    final int retval = MurmurHash.hash(data, length, seed);
+
+    // Assert result
+    Assert.assertEquals(0, retval);
+  }
+
+  @Test
+  public void hashInput1NegativeNegativeOutputArrayIndexOutOfBoundsException() {
+
+    // Arrange
+    final byte[] data = {(byte)0};
+    final int length = -2_080_374_782;
+    final int seed = -2_080_374_782;
+
+    // Act
+    thrown.expect(ArrayIndexOutOfBoundsException.class);
+    MurmurHash.hash(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hashInput1PositivePositiveOutputArrayIndexOutOfBoundsException() {
+
+    // Arrange
+    final byte[] data = {(byte)0};
+    final int length = 3;
+    final int seed = 3;
+
+    // Act
+    thrown.expect(ArrayIndexOutOfBoundsException.class);
+    MurmurHash.hash(data, length, seed);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void hashInput1PositivePositiveOutputZero() {
+
+    // Arrange
+    final byte[] data = {(byte)0};
+    final int length = 1;
+    final int seed = 1;
+
+    // Act
+    final int retval = MurmurHash.hash(data, length, seed);
+
+    // Assert result
+    Assert.assertEquals(0, retval);
+  }
+
+  @Test
+  public void hashLongInputZeroOutputZero() {
+
+    // Arrange
+    final long data = 0L;
+
+    // Act
+    final int retval = MurmurHash.hashLong(data);
+
+    // Assert result
+    Assert.assertEquals(0, retval);
+  }
+}

--- a/src/test/java/com/clearspring/analytics/stream/membership/BloomCalculationsTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/membership/BloomCalculationsTest.java
@@ -1,0 +1,118 @@
+// Copyright (c) Diffblue Limited. All rights reserved. 
+// Licensed under the Apache 2.0 license.
+
+package com.clearspring.analytics.stream.membership;
+
+import com.clearspring.analytics.stream.membership.BloomCalculations.BloomSpecification;
+import com.clearspring.analytics.stream.membership.BloomCalculations;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class BloomCalculationsTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void computeBestKInputPositiveOutputPositive() {
+
+    // Arrange
+    final int bucketsPerElement = 18;
+
+    // Act
+    final int retval = BloomCalculations.computeBestK(bucketsPerElement);
+
+    // Assert result
+    Assert.assertEquals(12, retval);
+  }
+
+  @Test
+  public void computeBestKInputPositiveOutputPositive2() {
+
+    // Arrange
+    final int bucketsPerElement = 50;
+
+    // Act
+    final int retval = BloomCalculations.computeBestK(bucketsPerElement);
+
+    // Assert result
+    Assert.assertEquals(14, retval);
+  }
+
+  @Test
+  public void computeBucketsAndKInputNaNOutputNotNull() {
+
+    // Arrange
+    final double maxFalsePosProb = Double.NaN;
+
+    // Act
+    final BloomSpecification retval = BloomCalculations.computeBucketsAndK(maxFalsePosProb);
+
+    // Assert result
+    Assert.assertNotNull(retval);
+    Assert.assertEquals(2, retval.bucketsPerElement);
+    Assert.assertEquals(1, retval.K);
+  }
+
+  @Test
+  public void computeBucketsAndKInputNegativeOutputNotNull() {
+
+    // Arrange
+    final double maxFalsePosProb = -0.1965;
+
+    // Act
+    final BloomSpecification retval = BloomCalculations.computeBucketsAndK(maxFalsePosProb);
+
+    // Assert result
+    Assert.assertNotNull(retval);
+    Assert.assertEquals(15, retval.bucketsPerElement);
+    Assert.assertEquals(8, retval.K);
+  }
+
+  @Test
+  public void computeBucketsAndKInputPositiveInfinityOutputNotNull() {
+
+    // Arrange
+    final double maxFalsePosProb = Double.POSITIVE_INFINITY;
+
+    // Act
+    final BloomSpecification retval = BloomCalculations.computeBucketsAndK(maxFalsePosProb);
+
+    // Assert result
+    Assert.assertNotNull(retval);
+    Assert.assertEquals(1, retval.bucketsPerElement);
+    Assert.assertEquals(2, retval.K);
+  }
+
+  @Test
+  public void computeBucketsAndKInputPositiveOutputNotNull() {
+
+    // Arrange
+    final double maxFalsePosProb = 0.237;
+
+    // Act
+    final BloomSpecification retval = BloomCalculations.computeBucketsAndK(maxFalsePosProb);
+
+    // Assert result
+    Assert.assertNotNull(retval);
+    Assert.assertEquals(3, retval.bucketsPerElement);
+    Assert.assertEquals(2, retval.K);
+  }
+
+  @Test
+  public void computeBucketsAndKInputPositiveOutputNotNull2() {
+
+    // Arrange
+    final double maxFalsePosProb = 0.349;
+
+    // Act
+    final BloomSpecification retval = BloomCalculations.computeBucketsAndK(maxFalsePosProb);
+
+    // Assert result
+    Assert.assertNotNull(retval);
+    Assert.assertEquals(3, retval.bucketsPerElement);
+    Assert.assertEquals(1, retval.K);
+  }
+}

--- a/src/test/java/com/clearspring/analytics/util/VarintTest.java
+++ b/src/test/java/com/clearspring/analytics/util/VarintTest.java
@@ -1,0 +1,94 @@
+// Copyright (c) Diffblue Limited. All rights reserved. 
+// Licensed under the Apache 2.0 license.
+
+package com.clearspring.analytics.util;
+
+import com.clearspring.analytics.util.Varint;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class VarintTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void readSignedVarIntInput0OutputPositive() {
+
+    // Arrange
+    final byte[] bytes = {};
+
+    // Act
+    final int retval = Varint.readSignedVarInt(bytes);
+
+    // Assert result
+    Assert.assertEquals(2_147_483_584, retval);
+  }
+
+  @Test
+  public void readUnsignedVarIntInput0OutputNegative() {
+
+    // Arrange
+    final byte[] bytes = {};
+
+    // Act
+    final int retval = Varint.readUnsignedVarInt(bytes);
+
+    // Assert result
+    Assert.assertEquals(-128, retval);
+  }
+
+  @Test
+  public void readUnsignedVarIntInput1OutputNegative() {
+
+    // Arrange
+    final byte[] bytes = {(byte)-128};
+
+    // Act
+    final int retval = Varint.readUnsignedVarInt(bytes);
+
+    // Assert result
+    Assert.assertEquals(-16_384, retval);
+  }
+
+  @Test
+  public void readUnsignedVarIntInput1OutputZero() {
+
+    // Arrange
+    final byte[] bytes = {(byte)0};
+
+    // Act
+    final int retval = Varint.readUnsignedVarInt(bytes);
+
+    // Assert result
+    Assert.assertEquals(0, retval);
+  }
+
+  @Test
+  public void writeSignedVarIntInputPositiveOutput1() {
+
+    // Arrange
+    final int value = 1;
+
+    // Act
+    final byte[] retval = Varint.writeSignedVarInt(value);
+
+    // Assert result
+    Assert.assertArrayEquals(new byte[] {(byte)2}, retval);
+  }
+
+  @Test
+  public void writeUnsignedVarIntInputPositiveOutput1() {
+
+    // Arrange
+    final int value = 1;
+
+    // Act
+    final byte[] retval = Varint.writeUnsignedVarInt(value);
+
+    // Assert result
+    Assert.assertArrayEquals(new byte[] {(byte)1}, retval);
+  }
+}


### PR DESCRIPTION
The test cases contained in this PR were written by Diffblue's Deeptest software. These tests are intended to help you detect regressions caused by future code changes.

One of our missions is to provide useful tests to open source projects. In return, we would appreciate your feedback on our tests to help us further improve our tool.

Results for various open source projects can be viewed at:

http://diff.blue/demo