### PR TITLE
Update diffblue.yml and add CYOA fallback phases

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -5,20 +5,61 @@ phases:
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
-   max-nondet-array-length: 100
-   java-max-vla-length: false
+   java-assume-inputs-non-null: true
+   java-max-vla-length: 48
+   max-nondet-array-length: 10
+   max-nondet-string-length: 10
+   string-printable: true
+   throw-runtime-exceptions: false
    unwind: 1
+ nextPhase:
+   not_analyzed: null
+   time_out: 3
 -
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
-   max-nondet-array-length: 100
-   java-max-vla-length: false
+   java-assume-inputs-non-null: false
+   java-max-vla-length:  96
+   max-nondet-array-length: 20
+   max-nondet-string-length: 50
+   string-printable: true
+   throw-runtime-exceptions: false
    unwind: 2
+ nextPhase:
+   time_out: 3
 -
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models.jar:.'
-   max-nondet-array-length: 100
-   java-max-vla-length: false
+   java-assume-inputs-non-null: false
+   java-max-vla-length:  192
+   max-nondet-array-length: 30
+   max-nondet-string-length: 10
+   string-printable: false
+   throw-runtime-exceptions: true
    unwind: 3
+-
+ timeout: 300
+ cbmcArguments:
+   classpath: '/tools/cbmc/models.jar:.'
+   java-assume-inputs-non-null: false
+   java-max-vla-length:  192
+   load-containing-class-only: true
+   max-nondet-array-length: 30
+   max-nondet-string-length: 50
+   string-printable: false
+   throw-runtime-exceptions: false
+   unwind: 4
+-
+ timeout: 300
+ cbmcArguments:
+   classpath: '/tools/cbmc/models.jar:.'
+   java-assume-inputs-non-null: false
+   java-max-vla-length:  192
+   max-nondet-array-length: 30
+   max-nondet-string-length: 50
+   single-function-only: true
+   string-printable: false
+   throw-runtime-exceptions: false
+   unwind: 5

--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,10 +1,10 @@
 cbmcArguments:
- depth: false
 phases:
 -
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
+   depth: 1500
    java-assume-inputs-non-null: true
    java-max-vla-length: 48
    max-nondet-array-length: 10
@@ -19,6 +19,7 @@ phases:
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
+   depth: 1500
    java-assume-inputs-non-null: false
    java-max-vla-length:  96
    max-nondet-array-length: 20
@@ -32,34 +33,63 @@ phases:
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models.jar:.'
+   depth: 3000
    java-assume-inputs-non-null: false
    java-max-vla-length:  192
    max-nondet-array-length: 30
-   max-nondet-string-length: 10
+   max-nondet-string-length: 100
    string-printable: false
    throw-runtime-exceptions: true
    unwind: 3
 -
  timeout: 300
  cbmcArguments:
-   classpath: '/tools/cbmc/models.jar:.'
-   java-assume-inputs-non-null: false
-   java-max-vla-length:  192
+   classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
+   depth: 1500
+   java-assume-inputs-non-null: true
+   java-max-vla-length: 48
    load-containing-class-only: true
-   max-nondet-array-length: 30
-   max-nondet-string-length: 50
-   string-printable: false
+   max-nondet-array-length: 10
+   max-nondet-string-length: 10
+   string-printable: true
    throw-runtime-exceptions: false
-   unwind: 4
+   unwind: 1
 -
  timeout: 300
  cbmcArguments:
    classpath: '/tools/cbmc/models.jar:.'
+   depth: 3000
+   java-assume-inputs-non-null: false
+   java-max-vla-length:  192
+   load-containing-class-only: true
+   max-nondet-array-length: 30
+   max-nondet-string-length: 100
+   string-printable: false
+   throw-runtime-exceptions: true
+   unwind: 3
+-
+ timeout: 300
+ cbmcArguments:
+   classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
+   depth: 1500
+   java-assume-inputs-non-null: true
+   java-max-vla-length: 48
+   max-nondet-array-length: 10
+   max-nondet-string-length: 10
+   single-function-only: true
+   string-printable: true
+   throw-runtime-exceptions: false
+   unwind: 1
+-
+ timeout: 300
+ cbmcArguments:
+   classpath: '/tools/cbmc/models.jar:.'
+   depth: 3000
    java-assume-inputs-non-null: false
    java-max-vla-length:  192
    max-nondet-array-length: 30
-   max-nondet-string-length: 50
+   max-nondet-string-length: 100
    single-function-only: true
    string-printable: false
-   throw-runtime-exceptions: false
-   unwind: 5
+   throw-runtime-exceptions: true
+   unwind: 3


### PR DESCRIPTION
The changes were done as follows. 

1. Given:
- diffblue.yml file used on Symphony, Reladomo, MyCollab and E-commerce Demo (they use the same options in the three phases),
- default platform options specified here https://github.com/diffblue/platform/blob/develop/docker/application-server/src/config/tools.json,
I constructed the first three phases to use the same options as the above standard benchmarks (previously I used the options from Tika) and for better readability, I explicitly state any options that differ from the default ones in any phase (so would get overridden in any phase).

2. Using the choose-your-own-adventure feature, I added two fallback phases - in case of timeouts or insufficient coverage (only in the third phase), fall back to a phase with load-containing-class-only and subsequently single-function-only.

Testing on stream-lib benchmark:
- old config: platform predicted 55.31% and verified 48.15% (in 27min),
- new config: platform predicted 66.69% (+11.38%) and verified 56.69% (+8.54%) (in 36min)

If approved, the diffblue.yml will be used on all 20 new benchmarks. Note that the purpose of this change is not to tweak the file as much as possible for all options but rather to quickly gain coverage using some low hanging fruit. 